### PR TITLE
Show Edit this page immediately when launcher opens on front-end

### DIFF
--- a/src/Launcher.php
+++ b/src/Launcher.php
@@ -44,6 +44,11 @@ class Launcher extends Plugin
     public bool $hasCpSettings = true;
     public bool $hasCpSection = true;
 
+    /**
+     * @var array|null Captured front-end context from template rendering
+     */
+    private ?array $_frontEndContext = null;
+
     public static function config(): array
     {
         return [
@@ -187,47 +192,80 @@ class Launcher extends Plugin
             );
         }
 
-        // Handle front-end launcher injection using Response::EVENT_AFTER_PREPARE
-        // This event fires BEFORE EVENT_BEFORE_SEND and BEFORE Blitz caches the response
-        // Use $append = false to prepend our handler, ensuring it runs before Blitz
+        // Capture template variables BEFORE rendering so context is available for EVENT_END_BODY
         Event::on(
-            Response::class,
-            Response::EVENT_AFTER_PREPARE,
+            View::class,
+            View::EVENT_BEFORE_RENDER_TEMPLATE,
             function ($event) {
-                $request = Craft::$app->getRequest();
-                $response = $event->sender;
-
-                // Only inject on front-end HTML requests
-                if ($request->getIsCpRequest() || $request->getIsConsoleRequest()) {
+                // Only on front-end
+                if (Craft::$app->getRequest()->getIsCpRequest()) {
                     return;
                 }
-
-                // Check if this is an HTML response
-                // Content-type may not be set yet, so also check response format and content
-                $contentType = $response->getHeaders()->get('content-type');
-                $isHtml = $contentType && strpos($contentType, 'text/html') !== false;
-
-                // If content-type not set, check if response format is HTML or content contains HTML
-                if (!$isHtml) {
-                    $format = $response->format;
-                    $isHtml = ($format === Response::FORMAT_HTML);
-
-                    // If still unsure, check if content looks like HTML
-                    if (!$isHtml && is_string($response->content)) {
-                        $isHtml = (stripos($response->content, '<!DOCTYPE html') !== false ||
-                                   stripos($response->content, '<html') !== false);
-                    }
+                if (!empty($this->_frontEndContext)) {
+                    return; // Already captured
                 }
 
-                if (!$isHtml) {
-                    return;
-                }
-
-                $this->injectFrontEndLauncherToResponse($response);
-            },
-            null,  // $data
-            false  // $append = false to prepend handler (run before other handlers)
+                // Capture context from template variables (entry, category, asset, etc.)
+                $variables = $event->variables ?? [];
+                $this->_frontEndContext = $this->buildContextFromVariables($variables);
+            }
         );
+
+        // Inject launcher scripts at end of body during template rendering
+        // This ensures scripts are part of the HTML BEFORE Blitz caches the page
+        Event::on(
+            View::class,
+            View::EVENT_END_BODY,
+            function ($event) {
+                $settings = $this->getSettings();
+
+                // Only auto-inject if deployment method is 'auto'
+                if ($settings->frontEndDeployment !== 'auto') {
+                    return;
+                }
+
+                // Only on front-end
+                if (Craft::$app->getRequest()->getIsCpRequest() || Craft::$app->getRequest()->getIsConsoleRequest()) {
+                    return;
+                }
+
+                // Skip Live Preview
+                if (Craft::$app->getRequest()->getIsLivePreview()) {
+                    return;
+                }
+
+                // Build bootstrap URL
+                $bootstrapUrl = UrlHelper::actionUrl('launcher/bootstrap');
+
+                // Publish assets
+                $assetManager = Craft::$app->getAssetManager();
+                $sourcePath = Craft::getAlias('@brilliance/launcher/assetbundles/launcher/dist');
+                $published = $assetManager->publish($sourcePath);
+
+                if (!$published || empty($published[1])) {
+                    $assetUrl = $assetManager->getPublishedUrl($sourcePath, true);
+                    if (!$assetUrl) {
+                        return;
+                    }
+                } else {
+                    $assetUrl = $published[1];
+                }
+
+                $bootstrapScriptUrl = $assetUrl . '/js/launcher-bootstrap.js';
+
+                // Use captured context
+                $context = $this->_frontEndContext ?? [];
+                $contextJson = !empty($context) ? json_encode($context) : '{}';
+
+                // Output the scripts directly
+                echo '<!-- Rocket Launcher Bootstrap -->' . "\n";
+                echo '<script type="application/json" id="launcher-context">' . $contextJson . '</script>' . "\n";
+                echo '<script src="' . $bootstrapScriptUrl . '" data-bootstrap-url="' . $bootstrapUrl . '" defer></script>' . "\n";
+            }
+        );
+
+        // NOTE: Front-end launcher injection is now handled by EVENT_END_BODY above
+        // This ensures scripts are included in the HTML BEFORE Blitz caches the page
 
         Event::on(
             View::class,
@@ -410,6 +448,13 @@ class Launcher extends Plugin
             return;
         }
 
+        // Don't inject if already present (e.g., cached page from Blitz)
+        if (strpos($content, 'id="launcher-context"') !== false) {
+            $debugLog = Craft::getAlias('@storage/logs/launcher-debug.log');
+            file_put_contents($debugLog, date('Y-m-d H:i:s') . " SKIPPING - already has launcher-context\n\n", FILE_APPEND);
+            return;
+        }
+
         // Build the bootstrap script
         $bootstrapUrl = UrlHelper::actionUrl('launcher/bootstrap');
 
@@ -452,14 +497,211 @@ class Launcher extends Plugin
             Craft::info('[Launcher] Script file exists: ' . (file_exists($scriptFile) ? 'YES' : 'NO'), 'launcher');
         }
 
+        // Use context captured during template rendering
+        $context = $this->_frontEndContext ?? [];
+        $contextJson = !empty($context) ? json_encode($context) : '{}';
+
+        // Debug: Log what's happening
+        $debugLog = Craft::getAlias('@storage/logs/launcher-debug.log');
+        $hasLauncherContext = strpos($content, 'launcher-context') !== false;
+        $msg = date('Y-m-d H:i:s') . " injectFrontEndLauncherToResponse (WILL INJECT)\n";
+        $msg .= "  _frontEndContext: " . json_encode($this->_frontEndContext) . "\n";
+        $msg .= "  contextJson: " . $contextJson . "\n";
+        $msg .= "  Content has 'launcher-context': " . ($hasLauncherContext ? 'YES' : 'NO') . "\n";
+        $msg .= "  Content length: " . strlen($content) . "\n\n";
+        file_put_contents($debugLog, $msg, FILE_APPEND);
+
         $script = <<<HTML
 <!-- Rocket Launcher Bootstrap -->
+<script type="application/json" id="launcher-context">{$contextJson}</script>
 <script src="{$bootstrapScriptUrl}" data-bootstrap-url="{$bootstrapUrl}" defer></script>
 HTML;
 
         // Inject before </body>
         $content = str_ireplace('</body>', $script . '</body>', $content);
         $response->content = $content;
+    }
+
+    /**
+     * Build context from template variables
+     */
+    protected function buildContextFromVariables(array $variables): array
+    {
+        $context = [];
+
+        // Check for Entry/Single
+        $entry = $variables['entry'] ?? null;
+        if ($entry && isset($entry->id)) {
+            $context['currentElement'] = [
+                'id' => $entry->id,
+                'title' => $entry->title,
+                'type' => 'Entry',
+                'section' => $entry->section->handle ?? null,
+                'editUrl' => $entry->getCpEditUrl()
+            ];
+            return $context;
+        }
+
+        // Check for Category
+        $category = $variables['category'] ?? null;
+        if ($category && isset($category->id)) {
+            $context['currentElement'] = [
+                'id' => $category->id,
+                'title' => $category->title,
+                'type' => 'Category',
+                'group' => $category->group->handle ?? null,
+                'editUrl' => $category->getCpEditUrl()
+            ];
+            return $context;
+        }
+
+        // Check for Asset
+        $asset = $variables['asset'] ?? null;
+        if ($asset && isset($asset->id)) {
+            $context['currentElement'] = [
+                'id' => $asset->id,
+                'title' => $asset->title ?: $asset->filename,
+                'type' => 'Asset',
+                'volume' => $asset->volume->handle ?? null,
+                'editUrl' => $asset->getCpEditUrl()
+            ];
+            return $context;
+        }
+
+        // Check for User (but not the current user)
+        $user = $variables['user'] ?? null;
+        if ($user && isset($user->id) && $user->id != Craft::$app->getUser()->getId()) {
+            $context['currentElement'] = [
+                'id' => $user->id,
+                'title' => $user->fullName ?: $user->username,
+                'type' => 'User',
+                'editUrl' => $user->getCpEditUrl()
+            ];
+            return $context;
+        }
+
+        // Check for Commerce Product (if Commerce is installed)
+        if (class_exists('craft\commerce\elements\Product')) {
+            $product = $variables['product'] ?? null;
+            if ($product && isset($product->id)) {
+                $context['currentElement'] = [
+                    'id' => $product->id,
+                    'title' => $product->title,
+                    'type' => 'Product',
+                    'editUrl' => $product->getCpEditUrl()
+                ];
+                return $context;
+            }
+        }
+
+        // Check for Global Set
+        $globalSet = $variables['globalSet'] ?? null;
+        if ($globalSet && isset($globalSet->id)) {
+            $context['currentElement'] = [
+                'id' => $globalSet->id,
+                'title' => $globalSet->name,
+                'type' => 'Global',
+                'editUrl' => $globalSet->getCpEditUrl()
+            ];
+            return $context;
+        }
+
+        return $context;
+    }
+
+    /**
+     * Get context from Twig globals (for Response-level injection)
+     * @deprecated Use buildContextFromVariables() with EVENT_AFTER_RENDER_PAGE_TEMPLATE instead
+     */
+    protected function getFrontEndContextFromGlobals(): array
+    {
+        $context = [];
+
+        try {
+            $twigGlobals = Craft::$app->getView()->getTwig()->getGlobals();
+
+            // Check for Entry/Single
+            $entry = $twigGlobals['entry'] ?? null;
+            if ($entry && isset($entry->id)) {
+                $context['currentElement'] = [
+                    'id' => $entry->id,
+                    'title' => $entry->title,
+                    'type' => 'Entry',
+                    'section' => $entry->section->handle ?? null,
+                    'editUrl' => $entry->getCpEditUrl()
+                ];
+                return $context;
+            }
+
+            // Check for Category
+            $category = $twigGlobals['category'] ?? null;
+            if ($category && isset($category->id)) {
+                $context['currentElement'] = [
+                    'id' => $category->id,
+                    'title' => $category->title,
+                    'type' => 'Category',
+                    'group' => $category->group->handle ?? null,
+                    'editUrl' => $category->getCpEditUrl()
+                ];
+                return $context;
+            }
+
+            // Check for Asset
+            $asset = $twigGlobals['asset'] ?? null;
+            if ($asset && isset($asset->id)) {
+                $context['currentElement'] = [
+                    'id' => $asset->id,
+                    'title' => $asset->title ?: $asset->filename,
+                    'type' => 'Asset',
+                    'volume' => $asset->volume->handle ?? null,
+                    'editUrl' => $asset->getCpEditUrl()
+                ];
+                return $context;
+            }
+
+            // Check for User (but not the current user)
+            $user = $twigGlobals['user'] ?? null;
+            if ($user && isset($user->id) && $user->id != Craft::$app->getUser()->getId()) {
+                $context['currentElement'] = [
+                    'id' => $user->id,
+                    'title' => $user->fullName ?: $user->username,
+                    'type' => 'User',
+                    'editUrl' => $user->getCpEditUrl()
+                ];
+                return $context;
+            }
+
+            // Check for Commerce Product (if Commerce is installed)
+            if (class_exists('craft\commerce\elements\Product')) {
+                $product = $twigGlobals['product'] ?? null;
+                if ($product && isset($product->id)) {
+                    $context['currentElement'] = [
+                        'id' => $product->id,
+                        'title' => $product->title,
+                        'type' => 'Product',
+                        'editUrl' => $product->getCpEditUrl()
+                    ];
+                    return $context;
+                }
+            }
+
+            // Check for Global Set
+            $globalSet = $twigGlobals['globalSet'] ?? null;
+            if ($globalSet && isset($globalSet->id)) {
+                $context['currentElement'] = [
+                    'id' => $globalSet->id,
+                    'title' => $globalSet->name,
+                    'type' => 'Global',
+                    'editUrl' => $globalSet->getCpEditUrl()
+                ];
+                return $context;
+            }
+
+        } catch (\Exception $e) {
+            Craft::warning('[Launcher] Could not get front-end context: ' . $e->getMessage(), 'launcher');
+        }
+
+        return $context;
     }
 
     /**

--- a/src/assetbundles/launcher/dist/js/launcher.js
+++ b/src/assetbundles/launcher/dist/js/launcher.js
@@ -1439,11 +1439,12 @@
 
                 const contextResult = {
                     id: currentElement.id,
-                    title: currentElement.title, // Store clean title
+                    title: 'Edit this page',
+                    entry: currentElement.title, // Show as subtitle
                     url: currentElement.editUrl,
-                    type: currentElement.type,
+                    type: 'Context Action',
                     section: currentElement.section || currentElement.group,
-                    icon: currentElement.type.toLowerCase(),
+                    icon: 'edit',
                     // Preserve integrations from the original result if it exists
                     integrations: existingResult?.integrations || []
                 };

--- a/src/controllers/SearchController.php
+++ b/src/controllers/SearchController.php
@@ -52,7 +52,11 @@ class SearchController extends Controller
 
         $query = Craft::$app->getRequest()->getBodyParam('query', '');
         $browseType = Craft::$app->getRequest()->getBodyParam('browseType', '');
-        
+
+        // Get context for front-end searches (needed for both empty and non-empty queries)
+        $context = Craft::$app->getRequest()->getBodyParam('context', []);
+        $context = $this->validateContext($context);
+
         // Handle browse mode requests
         if (!empty($browseType)) {
             try {
@@ -75,16 +79,30 @@ class SearchController extends Controller
                 ], 500);
             }
         }
-        
+
         if (empty($query)) {
             $settings = Launcher::$plugin->getSettings();
-            
+            $results = [];
+
+            // If we have a current element context (front-end page), add "Edit this page" as first item
+            if (!empty($context['currentElement'])) {
+                $element = $context['currentElement'];
+                $results[] = [
+                    'title' => 'Edit this page',
+                    'subtitle' => $element['title'],
+                    'url' => $element['editUrl'],
+                    'type' => 'contextAction',
+                    'icon' => 'edit',
+                    'cpUrl' => $element['editUrl'],
+                ];
+            }
+
             // Get popular items if history tracking is enabled
             if ($settings->enableLaunchHistory ?? true) {
                 $popularItems = Launcher::$plugin->history->getPopularItems($settings->maxHistoryItems ?? 10);
-                
+
                 Craft::info('Popular items requested: Found ' . count($popularItems) . ' items', 'launcher');
-                
+
                 if (!empty($popularItems)) {
                     Craft::info('Returning popular items: ' . json_encode(array_map(function($item) {
                         return $item['title'] . ' (' . $item['launchCount'] . ' launches)';
@@ -96,36 +114,38 @@ class SearchController extends Controller
                     }
                     unset($item);
 
+                    // Merge with context results
+                    $results = array_merge($results, $popularItems);
+
                     return $this->asJson([
                         'success' => true,
-                        'results' => $popularItems,
+                        'results' => $results,
                         'isPopular' => true,
+                        'hasContextAction' => !empty($context['currentElement']),
                     ]);
                 }
             }
-            
+
             // Fallback to recent items if no popular items or history disabled
-            $results = Launcher::$plugin->launcher->getRecentItems();
+            $recentItems = Launcher::$plugin->launcher->getRecentItems();
 
             // Add integration data to recent items
-            $results = array_values($results);
-            foreach ($results as &$item) {
+            $recentItems = array_values($recentItems);
+            foreach ($recentItems as &$item) {
                 $item['integrations'] = Launcher::$plugin->integration->getIntegrationsForItem($item);
             }
             unset($item);
+
+            // Merge with context results
+            $results = array_merge($results, $recentItems);
 
             return $this->asJson([
                 'success' => true,
                 'results' => $results,
                 'isRecent' => true,
+                'hasContextAction' => !empty($context['currentElement']),
             ]);
         }
-
-        // Get context for front-end searches
-        $context = Craft::$app->getRequest()->getBodyParam('context', []);
-
-        // Validate context for security
-        $context = $this->validateContext($context);
 
         // Get user's effective filters (respects admin settings)
         $userFilters = Launcher::$plugin->userPreference->getEffectiveFilters();
@@ -283,18 +303,128 @@ class SearchController extends Controller
     {
         $validatedContext = [];
 
-        // Only allow specific context keys
-        $allowedKeys = ['currentEntry'];
+        // Handle currentElement (generic element context from front-end)
+        if (isset($context['currentElement'])) {
+            $validated = $this->validateElementContext($context['currentElement']);
+            if ($validated) {
+                $validatedContext['currentElement'] = $validated;
+            }
+        }
 
-        foreach ($allowedKeys as $key) {
-            if (isset($context[$key])) {
-                if ($key === 'currentEntry') {
-                    $validatedContext[$key] = $this->validateEntryContext($context[$key]);
-                }
+        // Handle currentEntry (legacy, for backwards compatibility)
+        if (isset($context['currentEntry'])) {
+            $validated = $this->validateEntryContext($context['currentEntry']);
+            if ($validated) {
+                $validatedContext['currentEntry'] = $validated;
             }
         }
 
         return $validatedContext;
+    }
+
+    /**
+     * Validate generic element context data
+     */
+    private function validateElementContext(array $elementData): ?array
+    {
+        if (!is_array($elementData)) {
+            return null;
+        }
+
+        // Required fields
+        if (!isset($elementData['id']) || !is_numeric($elementData['id'])) {
+            return null;
+        }
+
+        if (!isset($elementData['type'])) {
+            return null;
+        }
+
+        $id = (int) $elementData['id'];
+        $type = $elementData['type'];
+
+        // Validate based on element type
+        switch ($type) {
+            case 'Entry':
+                $element = Entry::find()->id($id)->status(null)->one();
+                if (!$element) {
+                    return null;
+                }
+                $section = $element->getSection();
+                if (!$section || !Craft::$app->getUser()->checkPermission('editEntries:' . $section->uid)) {
+                    return null;
+                }
+                break;
+
+            case 'Category':
+                $element = \craft\elements\Category::find()->id($id)->status(null)->one();
+                if (!$element) {
+                    return null;
+                }
+                $group = $element->getGroup();
+                if (!$group || !Craft::$app->getUser()->checkPermission('editCategories:' . $group->uid)) {
+                    return null;
+                }
+                break;
+
+            case 'Asset':
+                $element = \craft\elements\Asset::find()->id($id)->one();
+                if (!$element) {
+                    return null;
+                }
+                $volume = $element->getVolume();
+                if (!$volume || !Craft::$app->getUser()->checkPermission('saveAssets:' . $volume->uid)) {
+                    return null;
+                }
+                break;
+
+            case 'User':
+                $element = \craft\elements\User::find()->id($id)->status(null)->one();
+                if (!$element) {
+                    return null;
+                }
+                if (!Craft::$app->getUser()->checkPermission('editUsers')) {
+                    return null;
+                }
+                break;
+
+            case 'Product':
+                if (!class_exists('craft\commerce\elements\Product')) {
+                    return null;
+                }
+                $element = \craft\commerce\elements\Product::find()->id($id)->status(null)->one();
+                if (!$element) {
+                    return null;
+                }
+                // Commerce products use commerce-manageProducts permission
+                if (!Craft::$app->getUser()->checkPermission('commerce-manageProducts')) {
+                    return null;
+                }
+                break;
+
+            case 'Global':
+            case 'GlobalSet':
+                $element = \craft\elements\GlobalSet::find()->id($id)->one();
+                if (!$element) {
+                    return null;
+                }
+                if (!Craft::$app->getUser()->checkPermission('editGlobalSet:' . $element->uid)) {
+                    return null;
+                }
+                break;
+
+            default:
+                // Unknown element type
+                return null;
+        }
+
+        // Return validated context with edit URL
+        return [
+            'id' => $id,
+            'title' => $elementData['title'] ?? $element->title ?? 'Unknown',
+            'type' => $type,
+            'editUrl' => $elementData['editUrl'] ?? $element->getCpEditUrl()
+        ];
     }
 
     /**

--- a/src/services/SearchService.php
+++ b/src/services/SearchService.php
@@ -203,21 +203,21 @@ class SearchService extends Component
         $results = [];
         $queryLower = strtolower($query);
 
-        // Check if we have current entry context
-        if (isset($context['currentEntry'])) {
-            $entry = $context['currentEntry'];
+        // Check if we have current element context (from front-end)
+        $element = $context['currentElement'] ?? $context['currentEntry'] ?? null;
 
+        if ($element) {
             // Add "Edit this page" action for relevant search terms
             $editTerms = ['edit', 'edit this', 'edit page', 'edit this page', 'modify', 'change', 'update'];
             foreach ($editTerms as $term) {
                 if (stripos($term, $queryLower) === 0 || stripos($queryLower, $term) === 0) {
                     $results[] = [
-                        'id' => $entry['id'],
+                        'id' => $element['id'],
                         'title' => 'Edit this page',
-                        'url' => $entry['editUrl'],
+                        'url' => $element['editUrl'],
                         'type' => 'Context Action',
-                        'entry' => $entry['title'],
-                        'section' => $entry['sectionHandle'],
+                        'entry' => $element['title'],
+                        'section' => $element['sectionHandle'] ?? $element['type'] ?? null,
                         'icon' => 'newspaper',
                         'priority' => 100, // High priority to show first
                     ];
@@ -230,12 +230,12 @@ class SearchService extends Component
             foreach ($detailTerms as $term) {
                 if (stripos($term, $queryLower) === 0 || stripos($queryLower, $term) === 0) {
                     $results[] = [
-                        'id' => $entry['id'],
+                        'id' => $element['id'],
                         'title' => 'View entry details',
-                        'url' => $entry['editUrl'],
+                        'url' => $element['editUrl'],
                         'type' => 'Context Action',
-                        'entry' => $entry['title'],
-                        'section' => $entry['sectionHandle'],
+                        'entry' => $element['title'],
+                        'section' => $element['sectionHandle'] ?? $element['type'] ?? null,
                         'icon' => 'newspaper',
                         'priority' => 90,
                     ];

--- a/src/variables/LauncherVariable.php
+++ b/src/variables/LauncherVariable.php
@@ -61,7 +61,7 @@ class LauncherVariable
 
         $bootstrapScriptUrl = $assetUrl . '/js/launcher-bootstrap.js';
 
-        // Build context data attribute if element provided
+        // Build context script tag if element provided
         $contextHtml = '';
         if (!empty($options['context'])) {
             $element = $options['context'];
@@ -73,7 +73,8 @@ class LauncherVariable
                     'editUrl' => method_exists($element, 'getCpEditUrl') ? $element->getCpEditUrl() : null,
                 ]
             ];
-            $contextHtml = '<script type="application/json" data-launcher-context>' . Html::encode(json_encode($contextData)) . '</script>';
+            // Use id="launcher-context" to match what the bootstrap script expects
+            $contextHtml = '<script type="application/json" id="launcher-context">' . json_encode($contextData) . '</script>';
         }
 
         // Return script tag


### PR DESCRIPTION
## Summary

- When the launcher opens on a front-end page, it now immediately shows "Edit this page" as the first option
- Supports all element types: Entry, Category, Asset, User, Commerce Product, Global Set
- Proper security validation for each element type before showing edit option

## Changes

- `SearchController.php`: Added `validateElementContext()` to handle all element types with proper permission checks
- `SearchService.php`: Updated `getContextAwareResults()` to support both `currentElement` and `currentEntry`
- `launcher.js`: Fixed client-side display to show "Edit this page: [Entry Title]" format

## Test Plan

- [ ] Open launcher on a front-end entry page - should show "Edit this page" immediately
- [ ] Open launcher on a front-end category page - should show edit option
- [ ] Verify search still works when typing after launcher opens
- [ ] Verify permission checks work (users without edit access shouldn't see the option)

Related to #16