### PR TITLE
Fix itemHash column length and welcome popup dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.4.1 - 2026-05-18
+
+> [!NOTE]
+> Users experiencing the itemHash database error should run `php craft migrate/all` after updating.
+
+### Fixed
+
+- **Database Schema**: Fixed `itemHash` column in Install migration to use correct 64-character length for SHA-256 hashes. Previously set to 32 characters, causing "Data too long for column 'itemHash'" errors on fresh installations. (Fixes [#19](https://github.com/brilliancenw/craft-launcher/issues/19))
+- **Welcome Screen**: Fixed the "Let's Get Started" welcome popup not dismissing properly. The popup now verifies the setting was saved successfully before closing, and displays a helpful error message if the database table is missing.
+- **Welcome Screen**: Added detection for missing `launcher_interface_settings` table. If the table doesn't exist, the welcome popup is skipped entirely and a warning message is displayed prompting users to run migrations.
+
 ## [v1.4.0] - 2026-03-20
 
 ### Full Page Caching Support (Fixes #12)

--- a/src/Launcher.php
+++ b/src/Launcher.php
@@ -1054,15 +1054,27 @@ HTML;
         if (!$tableStatus['exists']) {
             Craft::$app->getSession()->setFlash('launcher-table-missing',
                 'The Rocket Launcher user history table is missing. Launch history and popular items features will not work. ' .
-                'Try reinstalling the plugin or contact your developer.'
+                'Try running migrations: php craft migrate/all'
             );
         }
+
+        // Check interface settings table
+        $interfaceTableExists = $this->interface->tableExists();
+        if (!$interfaceTableExists) {
+            Craft::$app->getSession()->setFlash('launcher-interface-table-missing',
+                'The Rocket Launcher interface settings table is missing. Some features may not work correctly. ' .
+                'Try running migrations: php craft migrate/all'
+            );
+        }
+
+        // Only show welcome if interface table exists (so dismissal can be saved)
+        $firstRunCompleted = $interfaceTableExists ? $this->interface->isFirstRunCompleted() : true;
 
         return Craft::$app->getView()->renderTemplate(
             'launcher/settings',
             [
                 'settings' => $this->getSettings(),
-                'firstRunCompleted' => $this->interface->isFirstRunCompleted()
+                'firstRunCompleted' => $firstRunCompleted
             ]
         );
     }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -43,7 +43,7 @@ class Install extends Migration
                 'itemId' => $this->integer()->null(),
                 'itemTitle' => $this->text()->notNull(),
                 'itemUrl' => $this->text()->notNull(),
-                'itemHash' => $this->string(32)->notNull(),
+                'itemHash' => $this->string(64)->notNull(),
                 'launchCount' => $this->integer()->defaultValue(1),
                 'firstLaunchedAt' => $this->dateTime()->notNull(),
                 'lastLaunchedAt' => $this->dateTime()->notNull(),

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -330,9 +330,13 @@ document.addEventListener('DOMContentLoaded', function() {
         e.preventDefault();
         e.stopPropagation();
 
+        // Disable button to prevent double-clicks
+        dismissBtn.disabled = true;
+        dismissBtn.textContent = 'Saving...';
+
         // Save the setting via AJAX
         try {
-            await fetch('{{ actionUrl('launcher/settings/complete-first-run') }}', {
+            const response = await fetch('{{ actionUrl('launcher/settings/complete-first-run') }}', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -340,14 +344,32 @@ document.addEventListener('DOMContentLoaded', function() {
                     'Accept': 'application/json'
                 }
             });
+
+            const data = await response.json();
+
+            if (!response.ok || !data.success) {
+                throw new Error(data.error || 'Failed to save setting');
+            }
+
+            // Success - dismiss the overlay
+            overlay.classList.add('launcher-dismissing');
+            setTimeout(() => {
+                overlay.remove();
+            }, 500);
         } catch (error) {
             console.error('Failed to save first run setting:', error);
+            // Re-enable button and show error
+            dismissBtn.disabled = false;
+            dismissBtn.textContent = 'Let\'s Get Started!';
+            // Show error message
+            const errorDiv = document.createElement('div');
+            errorDiv.style.cssText = 'color: #dc3545; margin-top: 10px; font-size: 14px;';
+            errorDiv.textContent = 'Could not save setting. Please try running migrations: php craft migrate/all';
+            if (!dismissBtn.parentNode.querySelector('.error-message')) {
+                errorDiv.className = 'error-message';
+                dismissBtn.parentNode.appendChild(errorDiv);
+            }
         }
-
-        overlay.classList.add('launcher-dismissing');
-        setTimeout(() => {
-            overlay.remove();
-        }, 500);
     });
 });
 </script>


### PR DESCRIPTION
## Summary

- **Fixed itemHash column length** in Install migration to use correct 64-character length for SHA-256 hashes. Previously set to 32 characters, causing "Data too long for column 'itemHash'" database errors on fresh installations. (Fixes #19)
- **Fixed welcome popup dismissal** - The "Let's Get Started" popup now verifies the AJAX call succeeded before closing. If the save fails (e.g., missing database table), it displays a helpful error message prompting users to run migrations.
- **Added missing table detection** - If the `launcher_interface_settings` table doesn't exist, the welcome popup is skipped entirely and a warning flash message is displayed.

## Test plan

- [ ] Fresh install: Verify `itemHash` column is created with 64-character length
- [ ] Existing install with issue #19: Run `php craft migrate/all` and verify the error is resolved
- [ ] Welcome popup: Click "Let's Get Started" and verify it dismisses and stays dismissed on page reload
- [ ] Missing table scenario: If interface_settings table is missing, verify warning message appears and welcome popup is skipped